### PR TITLE
Some more build and fp16 changes

### DIFF
--- a/src/neural/sycl/network_sycl.cc.dp.cpp
+++ b/src/neural/sycl/network_sycl.cc.dp.cpp
@@ -311,16 +311,18 @@ class SyclNetwork : public Network {
     // (Ampere)
     // It turns dynamically off based on filter count (see
     // ResidualBlock<DataType>::Eval)
+    // TODO: fix res_block_fusing.
     if (kNumFilters % 32 == 0 && std::is_same<sycl::half, DataType>::value) {
-      use_res_block_winograd_fuse_opt_ = true;
+      use_res_block_winograd_fuse_opt_ = false;
     } else {
       use_res_block_winograd_fuse_opt_ = false;
     }
     // Override if set in backend-opts.
+#if  0
     if (!options.IsDefault<bool>("res_block_fusing")) {
       use_res_block_winograd_fuse_opt_ = options.Get<bool>("res_block_fusing");
     }
-
+#endif
     /*
     DPCT1005:86: The SYCL device version is different from CUDA Compute
     Compatibility. You may need to rewrite this code.


### PR DESCRIPTION
There are 3 parts to this:
1. Windows build changes: it seems `icx -fsycl` has a bug in the msvc style dependency support, listing the temporary header files generated as dependencies, making ninja rebuild the whole project for every change. The only way I found to work around this is by editing the `build.ninja` file to change the dependency tracking to the gcc style. Doing also the linker command change in the `build.ninja` file allows a single link step instead of two with the previous hack.
2. The fp16 crashes were due to using the unimplemented `res_block_fusing` feature, sp it is now switched off.
3. Some missing fp16 code paths are filled in.

This is still not enough to get fp16 working, but at least no crashes.