### PR TITLE
further build fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -647,6 +647,11 @@ if get_option('build_backends')
       else
         error('Building SYCL for the NVIDIA backend not yet supported')
       endif
+      if host_machine.system() == 'windows'
+        # For sycl under windows we need to link using icx to generate the device code.
+        # This script edits build.ninja for this and for an icx dependency issue.
+        meson.add_postconf_script('scripts/sycl_build_hack.py')
+      endif
   endif
 
 endif # if get_option('build_backends')

--- a/scripts/sycl_build_hack.py
+++ b/scripts/sycl_build_hack.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+
+dir = os.getenv('MESON_BUILD_ROOT')
+
+with open(dir + '/build.ninja', 'r') as file:
+  lines = file.readlines()
+
+updated = []
+dep_flag = False
+link_flag = False
+
+for line in lines:
+  # Replace xilink with icx -fsycl as the linker.
+  if not link_flag:
+    link_flag = 'xilink.exe' in line
+  if link_flag:
+    line = line.replace('xilink.exe', 'icx')
+    if 'rspfile_content' in line:
+      line = line.replace('/MACHINE:x64', '-fsycl')
+      line = line.replace('/OUT:', '-o ')
+    line = line.replace('/SUBSYSTEM:CONSOLE', '')
+    line = line.replace('/OPT:REF', '')
+  # Replace msvc compatible dependencies with gcc ones as icx output with /showincludes includes
+  # temporary header files causing full project rebuildsqu.
+  if line.startswith('rule') or line.startswith('build'):
+    dep_flag = 'cpp_COMPILER' in line
+  if dep_flag:
+    line = line.replace('deps = msvc', 'deps = gcc\n depfile = $out.d')
+    line = line.replace('/showIncludes', '/QMD')
+    if 'icx' in line:
+      line = line.replace('/Fo$out', '/Fo$out /QMF$out.d')
+  updated.append(line)
+
+with open(dir + '/build.ninja', 'w') as file:
+  file.writelines(updated)


### PR DESCRIPTION
I found out meson allows running a script file right after generation `build.ninja`, so converted the script to python and added it like that. This has two benefits, first it patches `build.ninja` every time it is rebuilt without depending on the build script (i.e. even when ninja triggers it), and second it is more understandable with finer control of the patching, which allowed me to restore full dependency functionality.

The change of the c compiler to cl was needed to allow ninja to rebuild without the `WINDRES` environment variable, as meson doesn't know the resource compiler to use with icx.